### PR TITLE
fix unused maxEditDistance in lookupCompound()

### DIFF
--- a/symspell-lib/src/main/java/io/github/mightguy/spellcheck/symspell/api/SpellChecker.java
+++ b/symspell-lib/src/main/java/io/github/mightguy/spellcheck/symspell/api/SpellChecker.java
@@ -47,7 +47,7 @@ public abstract class SpellChecker {
 
   public List<SuggestionItem> lookupCompound(String word, double editDistance)
       throws SpellCheckException {
-    return lookupCompound(word, spellCheckSettings.getMaxEditDistance(), true);
+    return lookupCompound(word, editDistance, true);
   }
 
 

--- a/symspell-lib/src/main/java/io/github/mightguy/spellcheck/symspell/impl/SymSpellCheck.java
+++ b/symspell-lib/src/main/java/io/github/mightguy/spellcheck/symspell/impl/SymSpellCheck.java
@@ -115,7 +115,7 @@ public class SymSpellCheck extends SpellChecker {
     }
     joinedTerm = joinedTerm.trim();
     double dist = stringDistance.getDistance(
-        joinedTerm.trim(), phrase, Math.pow(2, 31) - 1);
+        joinedTerm, phrase, Math.pow(2, 31) - 1);
 
     SuggestionItem suggestionItem = new SuggestionItem(joinedTerm, dist, joinedCount);
     return Collections.singletonList(suggestionItem);
@@ -187,7 +187,7 @@ public class SymSpellCheck extends SpellChecker {
 
     for (int j = 1; j < word.length(); j++) {
       String part1 = word.substring(0, j);
-      String part2 = word.substring(j, word.length());
+      String part2 = word.substring(j);
 
       List<SuggestionItem> suggestions1 = lookup(part1, Verbosity.TOP,
           maxEditDistance);


### PR DESCRIPTION
lookupCompound(String word, double editDistance) ignores the argument and incorrectly use the default value from the settings. 